### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,6 @@
 	"name": "mattradford/form-locator-for-gravity-forms",
     "description": "Lists WordPress pages and posts that contain Gravity Forms block or shortcode, including those deleted, trashed, and inactive.",
     "type": "plugin",
-    "license": "gplv2"
+    "license": "gplv2",
+    "prefer-stable" : true
 }

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "mattradford/form-locator-for-gravity-forms",
     "description": "Lists WordPress pages and posts that contain Gravity Forms block or shortcode, including those deleted, trashed, and inactive.",
     "type": "plugin",
-    "license": "gplv2",
+    "license": "GPL2",
+    "keywords": ["wordpress", "plugin"],
     "prefer-stable" : true
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+	"name": "mattradford/form-locator-for-gravity-forms",
+    "description": "Lists WordPress pages and posts that contain Gravity Forms block or shortcode, including those deleted, trashed, and inactive.",
+    "type": "plugin",
+    "license": "gplv2"
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mattradford/form-locator-for-gravity-forms",
+    "name": "mattradford/form-locator-for-gravity-forms",
     "description": "Lists WordPress pages and posts that contain Gravity Forms block or shortcode, including those deleted, trashed, and inactive.",
     "type": "plugin",
     "license": "GPL2",


### PR DESCRIPTION
Hi Chris

Thanks for your helpful plugin. Would you be able to add Composer support? This PR will do that, although you'd need to change the `name` in `composer.json` to `chrisegg/form-locator-for-gravity-forms`.

Thanks
Matt